### PR TITLE
メソッド名を大文字始まりに修正

### DIFF
--- a/TemplateMethod/AbstractDisplay.cs
+++ b/TemplateMethod/AbstractDisplay.cs
@@ -12,7 +12,7 @@ namespace TempleteMethod
         public abstract void Print();
         public abstract void Close();
 
-        public void display()
+        public void Display()
         {
             Open();
             for(int i = 0; i < 5; i++)


### PR DESCRIPTION
メソッド名を大文字始まりに修正